### PR TITLE
Fix hidden symbols on GCC

### DIFF
--- a/pybind11_abseil/import_status_module.h
+++ b/pybind11_abseil/import_status_module.h
@@ -12,6 +12,12 @@
   pybind11_abseil.status
 #endif
 
+#if defined(__GNUC__)
+#define PYBIND11_ABSEIL_DEFAULT_VISIBILITY __attribute__((visibility("default")))
+#else
+#define PYBIND11_ABSEIL_DEFAULT_VISIBILITY
+#endif
+
 namespace pybind11 {
 namespace google {
 
@@ -20,6 +26,7 @@ namespace google {
 // this function (enforced).
 // TODO(b/225205409): Remove bypass_regular_import.
 // bypass_regular_import is deprecated and can only be false (enforced).
+PYBIND11_ABSEIL_DEFAULT_VISIBILITY
 module_ ImportStatusModule(bool bypass_regular_import = false);
 
 }  // namespace google


### PR DESCRIPTION
The pybind11 namespace is declared with hidden visibility, and GCC propagates type visibility to declarations that use pybind11 types. Without this, the definitions would be hidden and unavailable to other shared objects.

Force default visibility.

See https://github.com/pybind/pybind11_protobuf/pull/239 & https://github.com/tensorflow/tensorflow/issues/103033